### PR TITLE
fix: add fallback dependency installation for mobile builds

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -164,12 +164,17 @@ jobs:
           java-version: '21'
 
       - name: Restore cached dependencies
+        id: cache-deps
         uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Build web assets
         run: npm run build:mobile
@@ -209,12 +214,17 @@ jobs:
           cache: 'npm'
 
       - name: Restore cached dependencies
+        id: cache-deps
         uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Build web assets
         run: npm run build:mobile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,12 +163,17 @@ jobs:
           java-version: '21'
 
       - name: Restore cached dependencies
+        id: cache-deps
         uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Build web assets
         run: npm run build:mobile
@@ -208,12 +213,17 @@ jobs:
           cache: 'npm'
 
       - name: Restore cached dependencies
+        id: cache-deps
         uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Build web assets
         run: npm run build:mobile


### PR DESCRIPTION
Mobile build jobs (Android/iOS) run on different OS runners than the dependency cache job, causing cache misses. Added npm ci fallback when cache is not found to ensure dependencies are available.

Fixes "vite: command not found" error in iOS builds.