### PR TITLE
fix(perf): eliminate N+1 queries in workout load and progression suggestions

### DIFF
--- a/src/adapters/repositories/drizzle/exercise.repository.adapter.ts
+++ b/src/adapters/repositories/drizzle/exercise.repository.adapter.ts
@@ -1,4 +1,4 @@
-import { eq, and, like, or, desc } from 'drizzle-orm';
+import { eq, and, like, or, desc, inArray } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { exercises } from '$lib/server/db/schema';
 import type * as schema from '$lib/server/db/schema';
@@ -20,6 +20,12 @@ export class DrizzleExerciseRepositoryAdapter implements IExerciseRepository {
 		const result = await this.db.select().from(exercises).where(eq(exercises.id, id)).limit(1);
 		if (!result[0]) return undefined;
 		return this.toEntity(result[0]);
+	}
+
+	async findByIds(ids: string[]): Promise<Exercise[]> {
+		if (ids.length === 0) return [];
+		const results = await this.db.select().from(exercises).where(inArray(exercises.id, ids));
+		return results.map((r) => this.toEntity(r));
 	}
 
 	async findByUserId(userId: string): Promise<Exercise[]> {

--- a/src/adapters/repositories/drizzle/personal-record.repository.adapter.ts
+++ b/src/adapters/repositories/drizzle/personal-record.repository.adapter.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc } from 'drizzle-orm';
+import { eq, and, desc, inArray } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { personalRecords, exercises } from '$lib/server/db/schema';
 import type * as schema from '$lib/server/db/schema';
@@ -30,6 +30,20 @@ export class DrizzlePersonalRecordRepositoryAdapter implements IPersonalRecordRe
 			.limit(1);
 		if (!result[0]) return undefined;
 		return this.toEntity(result[0]);
+	}
+
+	async findByUserIdAndExerciseIds(
+		userId: string,
+		exerciseIds: string[]
+	): Promise<PersonalRecord[]> {
+		if (exerciseIds.length === 0) return [];
+		const results = await this.db
+			.select()
+			.from(personalRecords)
+			.where(
+				and(eq(personalRecords.userId, userId), inArray(personalRecords.exerciseId, exerciseIds))
+			);
+		return results.map((r) => this.toEntity(r));
 	}
 
 	async findByUserId(userId: string): Promise<PersonalRecordDto[]> {

--- a/src/adapters/repositories/drizzle/split.repository.adapter.ts
+++ b/src/adapters/repositories/drizzle/split.repository.adapter.ts
@@ -16,7 +16,8 @@ import type {
 	UpdateSplitDto,
 	SplitFiltersDto,
 	SplitWithDetailsDto,
-	SplitDto
+	SplitDto,
+	SplitWithDaysDto
 } from '../../../core/domain/split/split.dto';
 import type { Pagination } from '../../../core/domain/common/value-objects';
 import { Split } from '../../../core/domain/split/split.entity';
@@ -172,6 +173,52 @@ export class DrizzleSplitRepositoryAdapter implements ISplitRepository {
 			.orderBy(desc(splits.createdAt));
 
 		return results.map((r) => this.toDto(r));
+	}
+
+	async findByUserIdWithDays(userId: string): Promise<SplitWithDaysDto[]> {
+		const userSplits = await this.db
+			.select({ id: splits.id, title: splits.title })
+			.from(splits)
+			.where(eq(splits.userId, userId))
+			.orderBy(desc(splits.createdAt));
+
+		if (userSplits.length === 0) return [];
+
+		const splitIds = userSplits.map((s) => s.id);
+		const days = await this.db
+			.select({
+				id: splitDays.id,
+				splitId: splitDays.splitId,
+				name: splitDays.name,
+				dayNumber: splitDays.dayNumber,
+				isRestDay: splitDays.isRestDay,
+				exerciseCount: sql<number>`cast(count(${dayExercises.id}) as integer)`
+			})
+			.from(splitDays)
+			.leftJoin(dayExercises, eq(splitDays.id, dayExercises.dayId))
+			.where(inArray(splitDays.splitId, splitIds))
+			.groupBy(splitDays.id)
+			.orderBy(splitDays.dayNumber);
+
+		const daysBySplitId = new Map<string, SplitWithDaysDto['days']>();
+		for (const day of days) {
+			if (!daysBySplitId.has(day.splitId)) {
+				daysBySplitId.set(day.splitId, []);
+			}
+			daysBySplitId.get(day.splitId)!.push({
+				id: day.id,
+				name: day.name,
+				dayNumber: day.dayNumber,
+				isRestDay: day.isRestDay,
+				exerciseCount: day.exerciseCount
+			});
+		}
+
+		return userSplits.map((s) => ({
+			id: s.id,
+			title: s.title,
+			days: daysBySplitId.get(s.id) || []
+		}));
 	}
 
 	async findWithFilters(

--- a/src/adapters/repositories/drizzle/workout-log.repository.adapter.ts
+++ b/src/adapters/repositories/drizzle/workout-log.repository.adapter.ts
@@ -348,6 +348,42 @@ export class DrizzleWorkoutLogRepositoryAdapter implements IWorkoutLogRepository
 		}));
 	}
 
+	async findExerciseHistoryBatch(
+		userId: string,
+		exerciseIds: string[],
+		limit = 5
+	): Promise<Map<string, ExercisePerformanceDto[]>> {
+		if (exerciseIds.length === 0) return new Map();
+
+		const results = await this.db
+			.select({
+				exerciseId: exerciseLogs.exerciseId,
+				date: workoutLogs.completedAt,
+				weight: exerciseLogs.weight,
+				sets: exerciseLogs.sets,
+				reps: exerciseLogs.reps
+			})
+			.from(exerciseLogs)
+			.innerJoin(workoutLogs, eq(exerciseLogs.workoutLogId, workoutLogs.id))
+			.where(and(eq(workoutLogs.userId, userId), inArray(exerciseLogs.exerciseId, exerciseIds)))
+			.orderBy(desc(workoutLogs.completedAt));
+
+		const grouped = new Map<string, ExercisePerformanceDto[]>();
+		for (const r of results) {
+			const exerciseId = r.exerciseId;
+			if (!exerciseId) continue;
+			if (!grouped.has(exerciseId)) {
+				grouped.set(exerciseId, []);
+			}
+			const list = grouped.get(exerciseId)!;
+			if (list.length < limit) {
+				list.push({ date: r.date, weight: r.weight, sets: r.sets, reps: r.reps });
+			}
+		}
+
+		return grouped;
+	}
+
 	private async calculateStreak(userId: string): Promise<number> {
 		const workouts = await this.db
 			.select({ completedAt: workoutLogs.completedAt })

--- a/src/core/domain/split/split.dto.ts
+++ b/src/core/domain/split/split.dto.ts
@@ -93,6 +93,18 @@ export interface SplitWithDetailsDto {
 	isLiked: boolean;
 }
 
+export interface SplitWithDaysDto {
+	id: string;
+	title: string;
+	days: {
+		id: string;
+		name: string;
+		dayNumber: number;
+		isRestDay: boolean;
+		exerciseCount: number;
+	}[];
+}
+
 export interface SplitDayWithExercisesDto {
 	id: string;
 	splitId: string;

--- a/src/core/ports/repositories/exercise.repository.port.ts
+++ b/src/core/ports/repositories/exercise.repository.port.ts
@@ -16,6 +16,11 @@ export interface IExerciseRepository {
 	findById(id: string): Promise<Exercise | undefined>;
 
 	/**
+	 * Finds exercises by IDs (batch)
+	 */
+	findByIds(ids: string[]): Promise<Exercise[]>;
+
+	/**
 	 * Finds all exercises for a user
 	 */
 	findByUserId(userId: string): Promise<Exercise[]>;

--- a/src/core/ports/repositories/personal-record.repository.port.ts
+++ b/src/core/ports/repositories/personal-record.repository.port.ts
@@ -9,6 +9,11 @@ export interface IPersonalRecordRepository {
 		exerciseId: string
 	): Promise<PersonalRecord | undefined>;
 
+	/**
+	 * Finds personal records for multiple exercises (batch)
+	 */
+	findByUserIdAndExerciseIds(userId: string, exerciseIds: string[]): Promise<PersonalRecord[]>;
+
 	findByUserId(userId: string): Promise<PersonalRecordDto[]>;
 
 	upsert(

--- a/src/core/ports/repositories/split.repository.port.ts
+++ b/src/core/ports/repositories/split.repository.port.ts
@@ -4,7 +4,8 @@ import type {
 	UpdateSplitDto,
 	SplitFiltersDto,
 	SplitWithDetailsDto,
-	SplitDto
+	SplitDto,
+	SplitWithDaysDto
 } from '../../domain/split/split.dto';
 import type { Pagination } from '../../domain/common/value-objects';
 
@@ -27,6 +28,11 @@ export interface ISplitRepository {
 	 * Finds all splits for a user (returns plain objects for serialization)
 	 */
 	findByUserId(userId: string): Promise<SplitDto[]>;
+
+	/**
+	 * Finds all splits for a user with their days and exercise counts (batch query)
+	 */
+	findByUserIdWithDays(userId: string): Promise<SplitWithDaysDto[]>;
 
 	/**
 	 * Finds splits with filters and pagination

--- a/src/core/ports/repositories/workout-log.repository.port.ts
+++ b/src/core/ports/repositories/workout-log.repository.port.ts
@@ -42,6 +42,15 @@ export interface IWorkoutLogRepository {
 	): Promise<ExercisePerformanceDto[]>;
 
 	/**
+	 * Get recent exercise performance history for multiple exercises (batch)
+	 */
+	findExerciseHistoryBatch(
+		userId: string,
+		exerciseIds: string[],
+		limit?: number
+	): Promise<Map<string, ExercisePerformanceDto[]>>;
+
+	/**
 	 * Check if user has completed at least one workout for a specific split
 	 */
 	hasCompletedWorkoutForSplit(userId: string, splitId: string): Promise<boolean>;

--- a/src/core/usecases/workout/get-progression-suggestions.usecase.ts
+++ b/src/core/usecases/workout/get-progression-suggestions.usecase.ts
@@ -25,6 +25,7 @@ export class GetProgressionSuggestionsUseCase {
 
 	/**
 	 * Generates progression suggestions for a list of exercises
+	 * Batch-loads all data upfront to avoid N+1 queries
 	 * @param {string} userId - ID of the user
 	 * @param {string[]} exerciseIds - IDs of exercises to analyze
 	 * @returns {Promise<Map<string, ProgressionSuggestionDto>>} Map of exercise IDs to progression suggestions
@@ -33,30 +34,41 @@ export class GetProgressionSuggestionsUseCase {
 		userId: string,
 		exerciseIds: string[]
 	): Promise<Map<string, ProgressionSuggestionDto>> {
+		if (exerciseIds.length === 0) return new Map();
+
+		// Batch-load all data in 3 parallel queries instead of 3*N sequential ones
+		const [exercisesList, personalRecordsList, performanceMap] = await Promise.all([
+			this.exerciseRepository.findByIds(exerciseIds),
+			this.personalRecordRepository.findByUserIdAndExerciseIds(userId, exerciseIds),
+			this.workoutLogRepository.findExerciseHistoryBatch(userId, exerciseIds, 5)
+		]);
+
+		const exerciseMap = new Map(exercisesList.map((e) => [e.id, e]));
+		const prMap = new Map(personalRecordsList.map((pr) => [pr.exerciseId, pr]));
+
 		const suggestions = new Map<string, ProgressionSuggestionDto>();
 
-		await Promise.all(
-			exerciseIds.map(async (exerciseId) => {
-				const suggestion = await this.getSuggestionForExercise(userId, exerciseId);
-				if (suggestion) {
-					suggestions.set(exerciseId, suggestion);
-				}
-			})
-		);
+		for (const exerciseId of exerciseIds) {
+			const suggestion = this.buildSuggestion(
+				exerciseId,
+				exerciseMap.get(exerciseId),
+				prMap.get(exerciseId),
+				performanceMap.get(exerciseId) || []
+			);
+			if (suggestion) {
+				suggestions.set(exerciseId, suggestion);
+			}
+		}
 
 		return suggestions;
 	}
 
-	private async getSuggestionForExercise(
-		userId: string,
-		exerciseId: string
-	): Promise<ProgressionSuggestionDto | null> {
-		const [exercise, personalRecord, recentPerformances] = await Promise.all([
-			this.exerciseRepository.findById(exerciseId),
-			this.personalRecordRepository.findByUserIdAndExerciseId(userId, exerciseId),
-			this.workoutLogRepository.findExerciseHistory(userId, exerciseId, 5)
-		]);
-
+	private buildSuggestion(
+		exerciseId: string,
+		exercise: { name: string; muscleGroup: string } | undefined,
+		personalRecord: { weight: number; reps: number; achievedAt: Date } | undefined,
+		recentPerformances: ExercisePerformanceDto[]
+	): ProgressionSuggestionDto | null {
 		if (!exercise) {
 			return null;
 		}
@@ -65,19 +77,21 @@ export class GetProgressionSuggestionsUseCase {
 		const isCompound = COMPOUND_MUSCLE_GROUPS.some((g) => muscleGroup.includes(g.toLowerCase()));
 		const increment = isCompound ? COMPOUND_INCREMENT : ISOLATION_INCREMENT;
 
+		const prData = personalRecord
+			? {
+					weight: personalRecord.weight,
+					reps: personalRecord.reps,
+					date: personalRecord.achievedAt
+				}
+			: null;
+
 		// No history case
 		if (recentPerformances.length === 0) {
 			return {
 				exerciseId,
 				exerciseName: exercise.name,
 				muscleGroup: exercise.muscleGroup,
-				currentPR: personalRecord
-					? {
-							weight: personalRecord.weight,
-							reps: personalRecord.reps,
-							date: personalRecord.achievedAt
-						}
-					: null,
+				currentPR: prData,
 				lastPerformance: null,
 				recentPerformances: [],
 				suggestedWeight: null,
@@ -95,15 +109,12 @@ export class GetProgressionSuggestionsUseCase {
 		let reason: ProgressionSuggestionDto['reason'] = 'maintain';
 
 		if (consecutiveSuccesses >= PROGRESSION_THRESHOLD && lastPerformance.weight !== null) {
-			// Ready to progress
 			suggestedWeight = lastPerformance.weight + increment;
 			reason = 'ready_to_progress';
 		} else if (recentPerformances.length === 1) {
-			// Only one session, maintain
 			suggestedWeight = lastPerformance.weight;
 			reason = 'maintain';
 		} else if (consecutiveSuccesses < PROGRESSION_THRESHOLD) {
-			// Not consistent enough yet
 			suggestedWeight = lastPerformance.weight;
 			reason = 'inconsistent';
 		}
@@ -112,13 +123,7 @@ export class GetProgressionSuggestionsUseCase {
 			exerciseId,
 			exerciseName: exercise.name,
 			muscleGroup: exercise.muscleGroup,
-			currentPR: personalRecord
-				? {
-						weight: personalRecord.weight,
-						reps: personalRecord.reps,
-						date: personalRecord.achievedAt
-					}
-				: null,
+			currentPR: prData,
 			lastPerformance: {
 				weight: lastPerformance.weight,
 				reps: lastPerformance.reps,

--- a/src/routes/(app)/workout/+page.server.ts
+++ b/src/routes/(app)/workout/+page.server.ts
@@ -19,26 +19,20 @@ export const load: PageServerLoad = async (event) => {
 	// Check for active session first
 	const activeSession = await container.getActiveWorkoutSession.execute(userId);
 
-	// Get splits for selection
-	const splitEntities = await container.splitRepository.findByUserId(userId);
-	const splits = await Promise.all(
-		splitEntities.map(async (s) => {
-			const details = await container.splitRepository.findByIdWithDetails(s.id);
-			return {
-				id: s.id,
-				title: s.title,
-				days:
-					details?.days
-						.filter((d) => !d.isRestDay && d.exercises.length > 0)
-						.map((d) => ({
-							id: d.id,
-							name: d.name,
-							dayNumber: d.dayNumber,
-							exerciseCount: d.exercises.length
-						})) || []
-			};
-		})
-	);
+	// Get splits with days in a batch query (avoids N+1)
+	const splitsWithDays = await container.splitRepository.findByUserIdWithDays(userId);
+	const splits = splitsWithDays.map((s) => ({
+		id: s.id,
+		title: s.title,
+		days: s.days
+			.filter((d) => !d.isRestDay && d.exerciseCount > 0)
+			.map((d) => ({
+				id: d.id,
+				name: d.name,
+				dayNumber: d.dayNumber,
+				exerciseCount: d.exerciseCount
+			}))
+	}));
 
 	// Check for URL params (from play button redirect)
 	const splitIdParam = url.searchParams.get('splitId');

--- a/tests/unit/usecases/add-comment.usecase.test.ts
+++ b/tests/unit/usecases/add-comment.usecase.test.ts
@@ -26,6 +26,7 @@ describe('AddCommentUseCase', () => {
 			findById: vi.fn(),
 			findByIdWithDetails: vi.fn(),
 			findByUserId: vi.fn(),
+			findByUserIdWithDays: vi.fn(),
 			findWithFilters: vi.fn(),
 			createWithDays: vi.fn(),
 			update: vi.fn(),

--- a/tests/unit/usecases/create-split.usecase.test.ts
+++ b/tests/unit/usecases/create-split.usecase.test.ts
@@ -13,6 +13,7 @@ describe('CreateSplitUseCase', () => {
 			findById: vi.fn(),
 			findByIdWithDetails: vi.fn(),
 			findByUserId: vi.fn(),
+			findByUserIdWithDays: vi.fn(),
 			findWithFilters: vi.fn(),
 			createWithDays: vi.fn(),
 			update: vi.fn(),

--- a/tests/unit/usecases/get-muscle-heatmap.usecase.test.ts
+++ b/tests/unit/usecases/get-muscle-heatmap.usecase.test.ts
@@ -60,6 +60,7 @@ describe('GetMuscleHeatmapUseCase', () => {
 			isOwnedByUser: vi.fn(),
 			getUserStats: vi.fn(),
 			findExerciseHistory: vi.fn(),
+			findExerciseHistoryBatch: vi.fn(),
 			hasCompletedWorkoutForSplit: vi.fn()
 		};
 

--- a/tests/unit/usecases/get-progression-suggestions.usecase.test.ts
+++ b/tests/unit/usecases/get-progression-suggestions.usecase.test.ts
@@ -43,12 +43,14 @@ describe('GetProgressionSuggestionsUseCase', () => {
 			isOwnedByUser: vi.fn(),
 			getUserStats: vi.fn(),
 			findExerciseHistory: vi.fn(),
+			findExerciseHistoryBatch: vi.fn().mockResolvedValue(new Map()),
 			hasCompletedWorkoutForSplit: vi.fn()
 		};
 
 		personalRecordRepository = {
 			findById: vi.fn(),
 			findByUserIdAndExerciseId: vi.fn(),
+			findByUserIdAndExerciseIds: vi.fn().mockResolvedValue([]),
 			findByUserId: vi.fn(),
 			upsert: vi.fn(),
 			delete: vi.fn(),
@@ -57,6 +59,7 @@ describe('GetProgressionSuggestionsUseCase', () => {
 
 		exerciseRepository = {
 			findById: vi.fn(),
+			findByIds: vi.fn().mockResolvedValue([]),
 			findByUserId: vi.fn(),
 			findWithFilters: vi.fn(),
 			create: vi.fn(),
@@ -75,9 +78,9 @@ describe('GetProgressionSuggestionsUseCase', () => {
 
 	describe('No History', () => {
 		it('should return no_history when exercise has no previous performances', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('chest'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(undefined);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([]);
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('chest')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(new Map());
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -92,13 +95,13 @@ describe('GetProgressionSuggestionsUseCase', () => {
 
 	describe('Single Session', () => {
 		it('should return maintain when only one session exists', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('chest'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('chest')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([
 				mockPersonalRecord(80, 10)
-			);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([
-				{ date: new Date(), weight: 80, sets: 3, reps: '10' }
 			]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(
+				new Map([['ex-1', [{ date: new Date(), weight: 80, sets: 3, reps: '10' }]]])
+			);
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -111,14 +114,21 @@ describe('GetProgressionSuggestionsUseCase', () => {
 
 	describe('Ready to Progress', () => {
 		it('should suggest progression after 2 consecutive successful sessions', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('chest'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('chest')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([
 				mockPersonalRecord(80, 10)
-			);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([
-				{ date: new Date(), weight: 80, sets: 3, reps: '10' },
-				{ date: new Date(Date.now() - 86400000), weight: 80, sets: 3, reps: '10' }
 			]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(
+				new Map([
+					[
+						'ex-1',
+						[
+							{ date: new Date(), weight: 80, sets: 3, reps: '10' },
+							{ date: new Date(Date.now() - 86400000), weight: 80, sets: 3, reps: '10' }
+						]
+					]
+				])
+			);
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -130,14 +140,21 @@ describe('GetProgressionSuggestionsUseCase', () => {
 		});
 
 		it('should use 1.25kg increment for isolation exercises', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('biceps'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('biceps')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([
 				mockPersonalRecord(20, 12)
-			);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([
-				{ date: new Date(), weight: 20, sets: 3, reps: '12' },
-				{ date: new Date(Date.now() - 86400000), weight: 20, sets: 3, reps: '12' }
 			]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(
+				new Map([
+					[
+						'ex-1',
+						[
+							{ date: new Date(), weight: 20, sets: 3, reps: '12' },
+							{ date: new Date(Date.now() - 86400000), weight: 20, sets: 3, reps: '12' }
+						]
+					]
+				])
+			);
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -150,14 +167,21 @@ describe('GetProgressionSuggestionsUseCase', () => {
 
 	describe('Inconsistent Sessions', () => {
 		it('should return inconsistent when weights differ between sessions', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('chest'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('chest')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([
 				mockPersonalRecord(80, 10)
-			);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([
-				{ date: new Date(), weight: 80, sets: 3, reps: '10' },
-				{ date: new Date(Date.now() - 86400000), weight: 75, sets: 3, reps: '10' }
 			]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(
+				new Map([
+					[
+						'ex-1',
+						[
+							{ date: new Date(), weight: 80, sets: 3, reps: '10' },
+							{ date: new Date(Date.now() - 86400000), weight: 75, sets: 3, reps: '10' }
+						]
+					]
+				])
+			);
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -170,9 +194,9 @@ describe('GetProgressionSuggestionsUseCase', () => {
 
 	describe('Muscle Group Detection', () => {
 		it('should use compound increment for chest exercises', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('chest'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(undefined);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([]);
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('chest')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(new Map());
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -180,9 +204,9 @@ describe('GetProgressionSuggestionsUseCase', () => {
 		});
 
 		it('should use compound increment for back exercises', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('back'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(undefined);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([]);
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('back')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(new Map());
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -190,9 +214,9 @@ describe('GetProgressionSuggestionsUseCase', () => {
 		});
 
 		it('should use compound increment for legs exercises', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('legs'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(undefined);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([]);
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('legs')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(new Map());
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -200,9 +224,9 @@ describe('GetProgressionSuggestionsUseCase', () => {
 		});
 
 		it('should use isolation increment for shoulders exercises', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('shoulders'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(undefined);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([]);
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('shoulders')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(new Map());
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -210,9 +234,9 @@ describe('GetProgressionSuggestionsUseCase', () => {
 		});
 
 		it('should use isolation increment for triceps exercises', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('triceps'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(undefined);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([]);
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('triceps')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(new Map());
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -249,11 +273,9 @@ describe('GetProgressionSuggestionsUseCase', () => {
 				new Date()
 			);
 
-			vi.mocked(exerciseRepository.findById)
-				.mockResolvedValueOnce(exercise1)
-				.mockResolvedValueOnce(exercise2);
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(undefined);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([]);
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([exercise1, exercise2]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(new Map());
 
 			const result = await useCase.execute('user-1', ['ex-1', 'ex-2']);
 
@@ -265,11 +287,11 @@ describe('GetProgressionSuggestionsUseCase', () => {
 
 	describe('Edge Cases', () => {
 		it('should handle null weight in history', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(mockExercise('chest'));
-			vi.mocked(personalRecordRepository.findByUserIdAndExerciseId).mockResolvedValue(undefined);
-			vi.mocked(workoutLogRepository.findExerciseHistory).mockResolvedValue([
-				{ date: new Date(), weight: null, sets: 3, reps: '10' }
-			]);
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([mockExercise('chest')]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(
+				new Map([['ex-1', [{ date: new Date(), weight: null, sets: 3, reps: '10' }]]])
+			);
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 
@@ -279,7 +301,9 @@ describe('GetProgressionSuggestionsUseCase', () => {
 		});
 
 		it('should skip exercises that do not exist', async () => {
-			vi.mocked(exerciseRepository.findById).mockResolvedValue(undefined);
+			vi.mocked(exerciseRepository.findByIds).mockResolvedValue([]);
+			vi.mocked(personalRecordRepository.findByUserIdAndExerciseIds).mockResolvedValue([]);
+			vi.mocked(workoutLogRepository.findExerciseHistoryBatch).mockResolvedValue(new Map());
 
 			const result = await useCase.execute('user-1', ['ex-1']);
 

--- a/tests/unit/usecases/like-split.usecase.test.ts
+++ b/tests/unit/usecases/like-split.usecase.test.ts
@@ -26,6 +26,7 @@ describe('LikeSplitUseCase', () => {
 			findById: vi.fn(),
 			findByIdWithDetails: vi.fn(),
 			findByUserId: vi.fn(),
+			findByUserIdWithDays: vi.fn(),
 			findWithFilters: vi.fn(),
 			createWithDays: vi.fn(),
 			update: vi.fn(),

--- a/tests/unit/usecases/log-workout.usecase.test.ts
+++ b/tests/unit/usecases/log-workout.usecase.test.ts
@@ -23,12 +23,14 @@ describe('LogWorkoutUseCase', () => {
 			isOwnedByUser: vi.fn(),
 			getUserStats: vi.fn(),
 			findExerciseHistory: vi.fn(),
+			findExerciseHistoryBatch: vi.fn(),
 			hasCompletedWorkoutForSplit: vi.fn()
 		};
 
 		personalRecordRepository = {
 			findById: vi.fn(),
 			findByUserIdAndExerciseId: vi.fn(),
+			findByUserIdAndExerciseIds: vi.fn(),
 			findByUserId: vi.fn(),
 			upsert: vi.fn(),
 			delete: vi.fn(),

--- a/tests/unit/usecases/split/create-review.usecase.test.ts
+++ b/tests/unit/usecases/split/create-review.usecase.test.ts
@@ -35,6 +35,7 @@ describe('CreateReviewUseCase', () => {
 			findById: vi.fn(),
 			findByIdWithDetails: vi.fn(),
 			findByUserId: vi.fn(),
+			findByUserIdWithDays: vi.fn(),
 			findWithFilters: vi.fn(),
 			createWithDays: vi.fn(),
 			update: vi.fn(),

--- a/tests/unit/usecases/start-workout-session.usecase.test.ts
+++ b/tests/unit/usecases/start-workout-session.usecase.test.ts
@@ -99,6 +99,7 @@ describe('StartWorkoutSessionUseCase', () => {
 			findById: vi.fn(),
 			findByIdWithDetails: vi.fn(),
 			findByUserId: vi.fn(),
+			findByUserIdWithDays: vi.fn(),
 			findWithFilters: vi.fn(),
 			createWithDays: vi.fn(),
 			update: vi.fn(),

--- a/tests/unit/usecases/workout/complete-workout-session.usecase.test.ts
+++ b/tests/unit/usecases/workout/complete-workout-session.usecase.test.ts
@@ -35,6 +35,7 @@ describe('CompleteWorkoutSessionUseCase', () => {
 			isOwnedByUser: vi.fn(),
 			getUserStats: vi.fn(),
 			findExerciseHistory: vi.fn(),
+			findExerciseHistoryBatch: vi.fn(),
 			hasCompletedWorkoutForSplit: vi.fn()
 		}) as unknown as Mocked<IWorkoutLogRepository>;
 
@@ -42,6 +43,7 @@ describe('CompleteWorkoutSessionUseCase', () => {
 		({
 			findById: vi.fn(),
 			findByUserIdAndExerciseId: vi.fn(),
+			findByUserIdAndExerciseIds: vi.fn(),
 			findByUserId: vi.fn(),
 			upsert: vi.fn(),
 			delete: vi.fn(),

--- a/tests/unit/usecases/workout/get-personal-records.usecase.test.ts
+++ b/tests/unit/usecases/workout/get-personal-records.usecase.test.ts
@@ -9,6 +9,7 @@ describe('GetPersonalRecordsUseCase', () => {
 			findByUserId: vi.fn(),
 			findById: vi.fn(),
 			findByUserIdAndExerciseId: vi.fn(),
+			findByUserIdAndExerciseIds: vi.fn(),
 			upsert: vi.fn(),
 			delete: vi.fn(),
 			isOwnedByUser: vi.fn()

--- a/tests/unit/usecases/workout/get-user-stats.usecase.test.ts
+++ b/tests/unit/usecases/workout/get-user-stats.usecase.test.ts
@@ -17,6 +17,7 @@ describe('GetUserStatsUseCase', () => {
 			exists: vi.fn(),
 			isOwnedByUser: vi.fn(),
 			findExerciseHistory: vi.fn(),
+			findExerciseHistoryBatch: vi.fn(),
 			hasCompletedWorkoutForSplit: vi.fn()
 		}) as unknown as Mocked<IWorkoutLogRepository>;
 

--- a/tests/unit/usecases/workout/get-workout-history.usecase.test.ts
+++ b/tests/unit/usecases/workout/get-workout-history.usecase.test.ts
@@ -17,6 +17,7 @@ describe('GetWorkoutHistoryUseCase', () => {
 			isOwnedByUser: vi.fn(),
 			getUserStats: vi.fn(),
 			findExerciseHistory: vi.fn(),
+			findExerciseHistoryBatch: vi.fn(),
 			hasCompletedWorkoutForSplit: vi.fn()
 		}) as unknown as Mocked<IWorkoutLogRepository>;
 


### PR DESCRIPTION
## Summary

- Add `findByUserIdWithDays` to split repository — loads all user splits with day/exercise counts in 2 queries instead of N+1
- Add batch methods to exercise, personal record, and workout log repositories (`findByIds`, `findByUserIdAndExerciseIds`, `findExerciseHistoryBatch`)
- Refactor `GetProgressionSuggestionsUseCase` to pre-fetch all data in 3 parallel queries, then build suggestions in-memory
- Update all test mocks to include the new interface methods

Closes #61
