### PR TITLE
fix(security): add HSTS header in production

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -88,6 +88,11 @@ const securityHeadersHandle: Handle = async ({ event, resolve }) => {
 		'camera=(), microphone=(), geolocation=(), payment=()'
 	);
 
+	// HSTS - enforce HTTPS on subsequent visits
+	if (process.env.NODE_ENV === 'production') {
+		response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+	}
+
 	// Content Security Policy (adjust as needed for your app)
 	if (process.env.NODE_ENV === 'production') {
 		response.headers.set(


### PR DESCRIPTION
## Summary

- Add `Strict-Transport-Security: max-age=31536000; includeSubDomains` header in production
- Prevents SSL stripping attacks by instructing browsers to always use HTTPS

Closes #63
