### PR TITLE
fix(security): add in-memory rate limiting fallback

### DIFF
--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -2,12 +2,19 @@ import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import { env } from '$env/dynamic/private';
 import type { RequestEvent } from '@sveltejs/kit';
+import { logger } from './logger';
 
 const UPSTASH_REDIS_REST_URL = env.UPSTASH_REDIS_REST_URL;
 const UPSTASH_REDIS_REST_TOKEN = env.UPSTASH_REDIS_REST_TOKEN;
 
 // Check if Redis is configured
 const isRedisConfigured = UPSTASH_REDIS_REST_URL && UPSTASH_REDIS_REST_TOKEN;
+
+if (!isRedisConfigured) {
+	logger.warn('Redis not configured — using in-memory rate limiting fallback', {
+		hint: 'Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN for distributed rate limiting'
+	});
+}
 
 // Create Redis instance only if configured
 const redis = isRedisConfigured
@@ -17,66 +24,89 @@ const redis = isRedisConfigured
 		})
 	: null;
 
-// Create rate limiters only if Redis is available
-export const authLimiter = redis
-	? new Ratelimit({
-			redis,
-			limiter: Ratelimit.slidingWindow(5, '15 m'), // 5 requests per 15 minutes
-			analytics: true,
-			prefix: 'ratelimit:auth'
-		})
-	: null;
+/**
+ * Simple in-memory sliding window rate limiter.
+ * Used as a fallback when Redis is unavailable.
+ * Not suitable for multi-instance deployments — use Redis for production.
+ */
+class InMemoryRateLimiter {
+	private windows = new Map<string, { timestamps: number[] }>();
+	private readonly maxRequests: number;
+	private readonly windowMs: number;
 
-export const apiLimiter = redis
-	? new Ratelimit({
-			redis,
-			limiter: Ratelimit.slidingWindow(100, '1 m'), // 100 requests per minute
-			analytics: true,
-			prefix: 'ratelimit:api'
-		})
-	: null;
+	constructor(maxRequests: number, windowMs: number) {
+		this.maxRequests = maxRequests;
+		this.windowMs = windowMs;
+	}
 
-export const uploadLimiter = redis
-	? new Ratelimit({
-			redis,
-			limiter: Ratelimit.slidingWindow(10, '1 h'), // 10 uploads per hour
-			analytics: true,
-			prefix: 'ratelimit:upload'
-		})
-	: null;
+	async limit(identifier: string): Promise<{
+		success: boolean;
+		limit: number;
+		remaining: number;
+		reset: number;
+	}> {
+		const now = Date.now();
+		const windowStart = now - this.windowMs;
 
-export const feedLimiter = redis
-	? new Ratelimit({
-			redis,
-			limiter: Ratelimit.slidingWindow(200, '1 m'), // 200 requests per minute
-			analytics: true,
-			prefix: 'ratelimit:feed'
-		})
-	: null;
+		let entry = this.windows.get(identifier);
+		if (!entry) {
+			entry = { timestamps: [] };
+			this.windows.set(identifier, entry);
+		}
 
-// Rate limiter for mutations (posts, comments, likes, etc.)
-export const mutationLimiter = redis
-	? new Ratelimit({
+		// Remove expired timestamps
+		entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
+
+		const remaining = Math.max(0, this.maxRequests - entry.timestamps.length);
+		const reset = now + this.windowMs;
+
+		if (entry.timestamps.length >= this.maxRequests) {
+			return { success: false, limit: this.maxRequests, remaining: 0, reset };
+		}
+
+		entry.timestamps.push(now);
+		return { success: true, limit: this.maxRequests, remaining: remaining - 1, reset };
+	}
+}
+
+function createInMemoryLimiter(maxRequests: number, windowMs: number): InMemoryRateLimiter {
+	return new InMemoryRateLimiter(maxRequests, windowMs);
+}
+
+type RateLimiter = Ratelimit | InMemoryRateLimiter;
+
+type Duration = `${number} ${'ms' | 's' | 'm' | 'h' | 'd'}`;
+
+function durationToMs(duration: Duration): number {
+	const [value, unit] = duration.split(' ') as [string, string];
+	const num = Number(value);
+	const multipliers: Record<string, number> = { ms: 1, s: 1000, m: 60000, h: 3600000, d: 86400000 };
+	return num * (multipliers[unit] ?? 1);
+}
+
+function createLimiter(maxRequests: number, window: Duration, prefix: string): RateLimiter {
+	if (redis) {
+		return new Ratelimit({
 			redis,
-			limiter: Ratelimit.slidingWindow(30, '1 m'), // 30 mutations per minute
+			limiter: Ratelimit.slidingWindow(maxRequests, window),
 			analytics: true,
-			prefix: 'ratelimit:mutation'
-		})
-	: null;
+			prefix: `ratelimit:${prefix}`
+		});
+	}
+	return createInMemoryLimiter(maxRequests, durationToMs(window));
+}
+
+// Rate limiters — Redis-backed when available, in-memory fallback otherwise
+export const authLimiter = createLimiter(5, '15 m', 'auth');
+export const apiLimiter = createLimiter(100, '1 m', 'api');
+export const uploadLimiter = createLimiter(10, '1 h', 'upload');
+export const feedLimiter = createLimiter(200, '1 m', 'feed');
+export const mutationLimiter = createLimiter(30, '1 m', 'mutation');
 
 export async function rateLimit(
 	event: RequestEvent,
-	limiter: Ratelimit | null
+	limiter: RateLimiter
 ): Promise<{ success: boolean; remaining: number; reset: Date }> {
-	// If no limiter is configured (Redis not available), allow all requests
-	if (!limiter) {
-		return {
-			success: true,
-			remaining: 999,
-			reset: new Date(Date.now() + 60000)
-		};
-	}
-
 	const identifier = event.locals.user?.id || event.getClientAddress();
 	const { success, limit, remaining, reset } = await limiter.limit(identifier);
 

--- a/tests/unit/lib/server/rate-limit.test.ts
+++ b/tests/unit/lib/server/rate-limit.test.ts
@@ -1,21 +1,22 @@
 import { describe, it, expect, vi } from 'vitest';
-import { rateLimit, rateLimitError } from '$lib/server/rate-limit';
+import { rateLimit, rateLimitError, feedLimiter } from '$lib/server/rate-limit';
 import type { RequestEvent } from '@sveltejs/kit';
 import type { Ratelimit } from '@upstash/ratelimit';
 
 describe('rate-limit', () => {
 	describe('rateLimit', () => {
-		it('should allow requests when no limiter is configured', async () => {
+		it('should allow requests with in-memory fallback limiter', async () => {
 			const mockEvent = {
 				locals: { user: null },
 				getClientAddress: () => '127.0.0.1',
 				setHeaders: vi.fn()
 			} as unknown as RequestEvent;
 
-			const result = await rateLimit(mockEvent, null);
+			// feedLimiter uses in-memory fallback when Redis is not configured (test env)
+			const result = await rateLimit(mockEvent, feedLimiter);
 
 			expect(result.success).toBe(true);
-			expect(result.remaining).toBe(999);
+			expect(result.remaining).toBeGreaterThanOrEqual(0);
 			expect(result.reset).toBeInstanceOf(Date);
 		});
 


### PR DESCRIPTION
## Summary

- Replace silent no-op when Redis is unavailable with an in-memory sliding window rate limiter
- Log a warning at startup when falling back to in-memory rate limiting

Closes #64
