### PR TITLE
fix(pwa): clean up service worker message listener on teardown

### DIFF
--- a/src/lib/utils/service-worker.ts
+++ b/src/lib/utils/service-worker.ts
@@ -34,12 +34,7 @@ export async function registerServiceWorker(): Promise<void> {
 		});
 
 		// Listen for messages from service worker
-		navigator.serviceWorker.addEventListener('message', (event) => {
-			if (event.data.type === 'SYNC_WORKOUT_DATA') {
-				// Trigger sync when service worker requests it
-				initializeSync();
-			}
-		});
+		navigator.serviceWorker.addEventListener('message', handleServiceWorkerMessage);
 
 		// Wait for service worker to be ready before marking offline ready
 		await navigator.serviceWorker.ready;
@@ -71,6 +66,15 @@ function handleOnline() {
 }
 
 /**
+ * Handle service worker messages
+ */
+function handleServiceWorkerMessage(event: MessageEvent) {
+	if (event.data.type === 'SYNC_WORKOUT_DATA') {
+		initializeSync();
+	}
+}
+
+/**
  * Initialize all offline capabilities
  */
 export function initializeOfflineSupport(): () => void {
@@ -98,5 +102,8 @@ export function initializeOfflineSupport(): () => void {
 	return () => {
 		cleanupConnectionMonitoring();
 		window.removeEventListener('online', handleOnline);
+		if ('serviceWorker' in navigator) {
+			navigator.serviceWorker.removeEventListener('message', handleServiceWorkerMessage);
+		}
 	};
 }


### PR DESCRIPTION
## Summary

- Extract anonymous service worker message listener into a named function
- Remove the listener in the cleanup function returned by `initializeOfflineSupport`

Closes #67
