### PR TITLE
fix(build): guard Better Auth init during vite build

### DIFF
--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -1,42 +1,51 @@
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { twoFactor } from 'better-auth/plugins';
+import { building } from '$app/environment';
 import { db } from '../db';
 import * as schema from '../db/schema';
 
-export const auth = betterAuth({
-	appName: 'SplitShare',
-	database: drizzleAdapter(db, {
-		provider: 'pg',
-		schema: {
-			user: schema.user,
-			session: schema.session,
-			account: schema.account,
-			verification: schema.verification,
-			twoFactor: schema.twoFactor
-		}
-	}),
-	emailAndPassword: {
-		enabled: true,
-		requireEmailVerification: true
-	},
-	session: {
-		expiresIn: 60 * 60 * 24 * 7, // 7 days
-		updateAge: 60 * 60 * 24 // 1 day
-	},
-	plugins: [
-		twoFactor({
-			issuer: 'SplitShare',
-			totpOptions: {
-				digits: 6,
-				period: 30
-			},
-			backupCodeOptions: {
-				amount: 10,
-				length: 8
+function createAuth() {
+	if (building) {
+		return null as unknown as ReturnType<typeof betterAuth>;
+	}
+
+	return betterAuth({
+		appName: 'SplitShare',
+		database: drizzleAdapter(db, {
+			provider: 'pg',
+			schema: {
+				user: schema.user,
+				session: schema.session,
+				account: schema.account,
+				verification: schema.verification,
+				twoFactor: schema.twoFactor
 			}
-		})
-	]
-});
+		}),
+		emailAndPassword: {
+			enabled: true,
+			requireEmailVerification: true
+		},
+		session: {
+			expiresIn: 60 * 60 * 24 * 7, // 7 days
+			updateAge: 60 * 60 * 24 // 1 day
+		},
+		plugins: [
+			twoFactor({
+				issuer: 'SplitShare',
+				totpOptions: {
+					digits: 6,
+					period: 30
+				},
+				backupCodeOptions: {
+					amount: 10,
+					length: 8
+				}
+			})
+		]
+	});
+}
+
+export const auth = createAuth();
 
 export type Auth = typeof auth;


### PR DESCRIPTION
betterAuth() was called unconditionally at module level, throwing BetterAuthError during vite build when secrets are unavailable. Wrap with the same building check used by the db module.