### PR TITLE
fix(build): skip auth in hooks during prerendering

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -147,6 +147,12 @@ const corsHandle: Handle = async ({ event, resolve }) => {
 };
 
 const authHandle: Handle = async ({ event, resolve }) => {
+	if (!auth) {
+		event.locals.session = null;
+		event.locals.user = null;
+		return resolve(event);
+	}
+
 	const sessionData = await auth.api.getSession({
 		headers: event.request.headers
 	});


### PR DESCRIPTION
The auth module returns null during build (added in #117). Guard authHandle so SvelteKit fallback page generation does not crash on auth.api.getSession().